### PR TITLE
Corrected the package name in Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install deps
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Set version on packages
         run: |
-          yarn workspace @usebridge/core version ${{ inputs.version }} --no-git-tag-version
+          yarn workspace @usebridge/sdk-core version ${{ inputs.version }} --no-git-tag-version
           yarn workspace @usebridge/react version ${{ inputs.version }} --no-git-tag-version
 
       - name: Create Release PR or Publish


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update release workflow to use `yarn install --immutable` and set version for `@usebridge/sdk-core` instead of `@usebridge/core`.
> 
> - **CI/Release workflow** (`.github/workflows/release.yml`):
>   - Install: switch from `yarn install --frozen-lockfile` to `yarn install --immutable`.
>   - Versioning: update workspace from `@usebridge/core` to `@usebridge/sdk-core` in the "Set version on packages" step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64f76a71f34e19400206f34036b6663a093af6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->