### PR TITLE
Workflow update, drop the git tag piece

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
 
       - name: Set version on packages
         run: |
-          yarn workspace @usebridge/sdk-core version ${{ inputs.version }} --no-git-tag-version
-          yarn workspace @usebridge/react version ${{ inputs.version }} --no-git-tag-version
+          yarn workspace @usebridge/sdk-core version ${{ inputs.version }}
+          yarn workspace @usebridge/sdk-react version ${{ inputs.version }}
 
       - name: Create Release PR or Publish
         uses: changesets/action@v1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _⚠️ The packages in this repository are currently in beta, please reach out 
 
 ## Packages
 
-### [`@usebridge/sdk-react](https://www.npmjs.com/package/@usebridge/sdk-react)
+### [`@usebridge/sdk-react`](https://www.npmjs.com/package/@usebridge/sdk-react)
 
 The headless React SDK to drive patient eligibility.
 Hooks allow you to focus on building your UX/UI, rather than the complexity of eligibility input and API calls.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usebridge/sdk-core",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Headless core SDK for Bridge - framework-agnostic",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usebridge/sdk-react",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "React hooks for Bridge headless SDK",
   "license": "MIT",
   "sideEffects": false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update release workflow versioning (use `@usebridge/sdk-react` and drop `--no-git-tag-version`), bump packages to `0.0.1`, and fix README link formatting.
> 
> - **CI/Release Workflow (`.github/workflows/release.yml`)**:
>   - Update versioning commands to target `@usebridge/sdk-react` (was `@usebridge/react`).
>   - Remove `--no-git-tag-version` from `yarn workspace ... version` commands.
> - **Packages**:
>   - Bump `@usebridge/sdk-core` and `@usebridge/sdk-react` versions from `0.0.0` to `0.0.1`.
> - **Docs**:
>   - Fix markdown link formatting for `@usebridge/sdk-react` in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a058c4fcf964bf8d9f4b6871ac59bd1ae30b5937. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->