### PR TITLE
Release trigger, dependency fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "The version of the TypeScript SDK that you would like to release"
-        required: true
-        type: string
+  release:
+    types: [published]
 
 jobs:
   release:
@@ -33,8 +29,8 @@ jobs:
 
       - name: Set version on packages
         run: |
-          yarn workspace @usebridge/sdk-core version ${{ inputs.version }}
-          yarn workspace @usebridge/sdk-react version ${{ inputs.version }}
+          yarn workspace @usebridge/sdk-core version ${{ github.event.release.tag_name }}
+          yarn workspace @usebridge/sdk-react version ${{ github.event.release.tag_name }}
 
       - name: Build and Publish packages
         run: yarn turbo run publish

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
       "cache": false
     },
     "publish": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "env": ["NODE_AUTH_TOKEN"],
       "outputs": [],
       "cache": false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch release workflow to run on GitHub Release publish and set package versions from the release tag; update `publish` task to depend on local `build`.
> 
> - **CI/Release Workflow (`.github/workflows/release.yml`)**:
>   - Add `release` trigger on published GitHub Releases; remove manual version input.
>   - Set package versions using `github.event.release.tag_name` for `@usebridge/sdk-core` and `@usebridge/sdk-react`.
> - **Build System (`turbo.json`)**:
>   - Change `publish` task dependency from `^build` to `build` (local only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2b5aea3a4dd2d88f6d2f0dc0d680fae9767e47a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->