### PR TITLE
Fix type submission logic in use-hard-eligibility-submit.ts

### DIFF
--- a/examples/react-demo/src/app/hard-eligibility-follow-up/hard-eligibility-follow-up-session-form.tsx
+++ b/examples/react-demo/src/app/hard-eligibility-follow-up/hard-eligibility-follow-up-session-form.tsx
@@ -1,7 +1,4 @@
-import {
-  useHardEligibilityState,
-  useHardEligibilitySubmit,
-} from "@usebridge/sdk-react"
+import { useHardEligibilityState, useHardEligibilitySubmit } from "@usebridge/sdk-react"
 import { Button, Stack, Typography } from "@mui/material"
 import { StatePicker } from "../components/state-picker"
 
@@ -25,4 +22,3 @@ export const HardEligibilityFollowUpSessionForm = () => {
     </Stack>
   )
 }
-

--- a/packages/react/src/hard-eligibility/use-hard-eligibility-submit.ts
+++ b/packages/react/src/hard-eligibility/use-hard-eligibility-submit.ts
@@ -15,13 +15,18 @@ interface HardEligibilitySubmitCallbackArgs {
   clinicalInfo?: ClinicalInfo
 }
 
+interface HardEligibilitySubmitFn {
+  (): Promise<HardEligibilitySessionState>
+  (args: HardEligibilitySubmitCallbackArgs): Promise<HardEligibilitySessionState>
+}
+
 /**
  * Returns a function to submit requests into the Hard Eligibility Session
  * Parses the arguments required for the submission from the EligibilityInput
  */
 export function useHardEligibilitySubmit(): {
   isDisabled: boolean
-  submit: (args?: HardEligibilitySubmitCallbackArgs) => Promise<HardEligibilitySessionState>
+  submit: HardEligibilitySubmitFn
 } {
   const session = useHardEligibilitySession()
   const { state, payer, firstName, lastName, dateOfBirth, memberId } = useEligibilityInput()
@@ -33,7 +38,7 @@ export function useHardEligibilitySubmit(): {
 
   const isDisabled = !inputIsValid || !HardEligibility.canSubmit(status)
 
-  const submit = useCallback(
+  const submit = useCallback<HardEligibilitySubmitFn>(
     ({ clinicalInfo }: HardEligibilitySubmitCallbackArgs = {}) => {
       if (!state.value) throw new Error("State is required")
 

--- a/packages/react/src/hard-eligibility/use-hard-eligibility-submit.ts
+++ b/packages/react/src/hard-eligibility/use-hard-eligibility-submit.ts
@@ -21,7 +21,7 @@ interface HardEligibilitySubmitCallbackArgs {
  */
 export function useHardEligibilitySubmit(): {
   isDisabled: boolean
-  submit: () => Promise<HardEligibilitySessionState>
+  submit: (args?: HardEligibilitySubmitCallbackArgs) => Promise<HardEligibilitySessionState>
 } {
   const session = useHardEligibilitySession()
   const { state, payer, firstName, lastName, dateOfBirth, memberId } = useEligibilityInput()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a TypeScript typing/overload fix for `useHardEligibilitySubmit` with no behavioral changes to submission logic; main impact is on downstream compile-time types.
> 
> **Overview**
> Fixes the `useHardEligibilitySubmit` hook typing so `submit` correctly supports an optional `{ clinicalInfo }` argument via an overloaded `HardEligibilitySubmitFn`, and applies that type to the `useCallback` return.
> 
> Also cleans up the demo import formatting for `HardEligibilityFollowUpSessionForm` with no functional change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9cc0f38b7828c0254828dd7c6a53bb440abc287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->