### PR TITLE
(bug) Fixed type issue at the `useHardEligibilitySubmit` hook

### DIFF
--- a/examples/react-demo/src/app/hard-eligibility-follow-up/hard-eligibility-follow-up-session-form.tsx
+++ b/examples/react-demo/src/app/hard-eligibility-follow-up/hard-eligibility-follow-up-session-form.tsx
@@ -1,7 +1,4 @@
-import {
-  useHardEligibilityState,
-  useHardEligibilitySubmit,
-} from "@usebridge/sdk-react"
+import { useHardEligibilityState, useHardEligibilitySubmit } from "@usebridge/sdk-react"
 import { Button, Stack, Typography } from "@mui/material"
 import { StatePicker } from "../components/state-picker"
 
@@ -19,10 +16,9 @@ export const HardEligibilityFollowUpSessionForm = () => {
 
       <StatePicker />
 
-      <Button disabled={isDisabled} variant="contained" onClick={submit}>
+      <Button disabled={isDisabled} variant="contained" onClick={() => void submit()}>
         Submit Hard Eligibility
       </Button>
     </Stack>
   )
 }
-

--- a/examples/react-demo/src/app/hard-eligibility/hard-eligibility-session-form.tsx
+++ b/examples/react-demo/src/app/hard-eligibility/hard-eligibility-session-form.tsx
@@ -70,7 +70,7 @@ export const HardEligibilitySessionForm = () => {
         />
       )}
 
-      <Button disabled={isDisabled} variant="contained" onClick={submit}>
+      <Button disabled={isDisabled} variant="contained" onClick={() => void submit()}>
         Submit Hard Eligibility
       </Button>
     </Stack>

--- a/packages/react/src/hard-eligibility/use-hard-eligibility-submit.ts
+++ b/packages/react/src/hard-eligibility/use-hard-eligibility-submit.ts
@@ -15,14 +15,15 @@ interface HardEligibilitySubmitCallbackArgs {
   clinicalInfo?: ClinicalInfo
 }
 
+type SubmitFunction = (
+  args?: HardEligibilitySubmitCallbackArgs,
+) => Promise<HardEligibilitySessionState>
+
 /**
  * Returns a function to submit requests into the Hard Eligibility Session
  * Parses the arguments required for the submission from the EligibilityInput
  */
-export function useHardEligibilitySubmit(): {
-  isDisabled: boolean
-  submit: () => Promise<HardEligibilitySessionState>
-} {
+export function useHardEligibilitySubmit(): { isDisabled: boolean; submit: SubmitFunction } {
   const session = useHardEligibilitySession()
   const { state, payer, firstName, lastName, dateOfBirth, memberId } = useEligibilityInput()
 
@@ -33,8 +34,8 @@ export function useHardEligibilitySubmit(): {
 
   const isDisabled = !inputIsValid || !HardEligibility.canSubmit(status)
 
-  const submit = useCallback(
-    ({ clinicalInfo }: HardEligibilitySubmitCallbackArgs = {}) => {
+  const submit: SubmitFunction = useCallback(
+    ({ clinicalInfo } = {}) => {
       if (!state.value) throw new Error("State is required")
 
       const submitArgs: Parameters<typeof session.submit>[0] = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a small TypeScript typing/API surface adjustment for `useHardEligibilitySubmit` plus demo call-site tweaks, with no change to submission behavior.
> 
> **Overview**
> **Fixes a typing issue in `useHardEligibilitySubmit`.** The hook now explicitly types `submit` as a promise-returning function that accepts optional args (e.g., `clinicalInfo`), aligning the implementation and exported signature.
> 
> The React demo forms update their button handlers to call `submit` via `() => void submit()` to satisfy async handler/lint expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8b4d7d968fe6252c499282a8b59cbd4c55875d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->