### PR TITLE
update node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22.x"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@usebridge"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because upgrading the runtime for CI and publishing can surface Node/yarn/tooling incompatibilities and potentially break builds or release publishing.
> 
> **Overview**
> **Upgrades workflow runtime:** CI (`ci.yml`) and release (`release.yml`) now use Node.js `22.x` via `actions/setup-node` instead of the previous Node 20 configuration.
> 
> No other workflow steps or build/test/publish commands are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95b86a54617dd4637e03925c2965011b325eff54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->