### PR TITLE
Optimistic soft check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 ## Packages
 
+### [`@usebridge/sdk`](https://www.npmjs.com/package/@usebridge/sdk)
+
+The default Bridge SDK for non-React environments — API routes, workers, scripts, and vanilla JS clients.
+Call `softEligibility()` or `hardEligibility()` with complete inputs and receive the final result.
+
 ### [`@usebridge/sdk-react`](https://www.npmjs.com/package/@usebridge/sdk-react)
 
 The headless React SDK to drive patient eligibility.
@@ -15,10 +20,32 @@ Hooks allow you to focus on building your UX/UI, rather than the complexity of e
 
 ### [`@usebridge/sdk-core`](https://www.npmjs.com/package/@usebridge/sdk-core)
 
-TypeScript SDK, browser and node-compatible, for managing eligibility checks.
-Provides an abstraction over the eligibility API's.
+Low-level, framework-agnostic SDK for managing eligibility checks.
+Use when you need raw session control, EventEmitter lifecycle, or other advanced behavior.
 
-_If using React, do not use this directly._
+| Use case                            | Package                |
+| ----------------------------------- | ---------------------- |
+| React app                           | `@usebridge/sdk-react` |
+| Server, script, or non-React client | `@usebridge/sdk`       |
+| Raw session control / EventEmitter  | `@usebridge/sdk-core`  |
+
+## Usage (`@usebridge/sdk`)
+
+```typescript
+import { createBridgeClient } from "@usebridge/sdk"
+import type { BridgeSdkConfig } from "@usebridge/sdk-core"
+
+const bridge = createBridgeClient({
+  publishableKey: "pk_...",
+  environment: "sandbox",
+} satisfies BridgeSdkConfig)
+
+const result = await bridge.softEligibility({
+  serviceTypeIds: ["svt_..."],
+  payerId: "pyr_...",
+  state: "CA",
+})
+```
 
 ## Analytics Events
 

--- a/examples/node/.env.example
+++ b/examples/node/.env.example
@@ -1,0 +1,8 @@
+# Bridge publishable API key (Dashboard > Developers > API Keys)
+BRIDGE_PUBLISHABLE_KEY=pk_your_key_here
+
+# production | sandbox
+BRIDGE_ENVIRONMENT=sandbox
+
+# Comma-separated service type IDs used as defaults in soft/hard scripts
+BRIDGE_SERVICE_TYPES=svt_demo_1,svt_demo_2

--- a/examples/node/.gitignore
+++ b/examples/node/.gitignore
@@ -1,0 +1,2 @@
+.env
+.env.local

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -1,0 +1,26 @@
+# Node demo (`@usebridge/sdk`)
+
+Interactive CLI scripts demonstrating `@usebridge/sdk` without React.
+
+## Setup
+
+1. Copy `.env.example` to `.env` or `.env.local` and set your publishable key and service type IDs.
+   Both files are supported; `.env.local` overrides `.env`. Missing files are fine.
+   You can mirror values from `examples/react-demo/.env.local` (`NEXT_PUBLIC_*` → `BRIDGE_*`).
+2. From the repo root: `yarn install`
+
+## Scripts
+
+| Command       | Description                  |
+| ------------- | ---------------------------- |
+| `yarn search` | Search payers by name        |
+| `yarn soft`   | Run a soft eligibility check |
+| `yarn hard`   | Run a hard eligibility check |
+
+Run from this directory, or from the repo root:
+
+```bash
+yarn workspace node-demo soft
+```
+
+Prompts collect inputs interactively via [@inquirer/prompts](https://github.com/SBoudrias/Inquirer.js).

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "node-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "search": "tsx src/scripts/search-payers.ts",
+    "soft": "tsx src/scripts/soft-eligibility.ts",
+    "hard": "tsx src/scripts/hard-eligibility.ts",
+    "build": "echo \"(no build)\"",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
+    "test": "echo \"(no tests)\"",
+    "clean": "echo \"(no clean)\""
+  },
+  "dependencies": {
+    "@inquirer/prompts": "^7.5.1",
+    "@usebridge/api": ">=1.1.0-0",
+    "@usebridge/sdk": "workspace:*",
+    "@usebridge/sdk-core": "workspace:*",
+    "dotenv": "^16.6.1",
+    "envalid": "^8.1.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/node/src/lib/bridge-client.ts
+++ b/examples/node/src/lib/bridge-client.ts
@@ -1,0 +1,16 @@
+import { createBridgeClient, type BridgeClient } from "@usebridge/sdk"
+import { consoleLogger } from "@usebridge/sdk-core"
+import { env } from "./env.js"
+
+let client: BridgeClient | undefined
+
+export function getBridgeClient(): BridgeClient {
+  if (!client) {
+    client = createBridgeClient({
+      publishableKey: env.BRIDGE_PUBLISHABLE_KEY,
+      environment: env.BRIDGE_ENVIRONMENT,
+      logger: consoleLogger,
+    })
+  }
+  return client
+}

--- a/examples/node/src/lib/date-object.ts
+++ b/examples/node/src/lib/date-object.ts
@@ -1,0 +1,13 @@
+import type { DateObject } from "@usebridge/sdk-core"
+
+const DATESTAMP_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/
+
+export function datestampToDateObject(value: string): DateObject {
+  const match = DATESTAMP_PATTERN.exec(value.trim())
+  if (!match) {
+    throw new Error('Date of birth must be "YYYY-MM-DD"')
+  }
+
+  const [, year, month, day] = match
+  return { year: year!, month: month!, day: day! }
+}

--- a/examples/node/src/lib/env.ts
+++ b/examples/node/src/lib/env.ts
@@ -1,0 +1,22 @@
+import "./load-env.js"
+import { cleanEnv, str } from "envalid"
+
+export const env = cleanEnv(process.env, {
+  BRIDGE_PUBLISHABLE_KEY: str({
+    desc: "Bridge publishable API key (pk_...)",
+  }),
+  BRIDGE_ENVIRONMENT: str({
+    desc: "Bridge environment: production or sandbox",
+    default: "sandbox",
+  }),
+  BRIDGE_SERVICE_TYPES: str({
+    desc: "Comma-separated default service type IDs",
+    default: "svt_demo_1,svt_demo_2",
+  }),
+})
+
+export function getDefaultServiceTypeIds(): string[] {
+  return env.BRIDGE_SERVICE_TYPES.split(",")
+    .map((id) => id.trim())
+    .filter(Boolean)
+}

--- a/examples/node/src/lib/load-env.ts
+++ b/examples/node/src/lib/load-env.ts
@@ -1,0 +1,5 @@
+import dotenv from "dotenv"
+
+// Missing files are ignored. `.env.local` wins over `.env` for duplicate keys.
+dotenv.config({ path: ".env.local" })
+dotenv.config({ path: ".env" })

--- a/examples/node/src/lib/output.ts
+++ b/examples/node/src/lib/output.ts
@@ -1,0 +1,7 @@
+export function printJson(data: unknown): void {
+  process.stdout.write(`${JSON.stringify(data, null, 2)}\n`)
+}
+
+export function printMessage(message: string): void {
+  process.stdout.write(`${message}\n`)
+}

--- a/examples/node/src/lib/prompts.ts
+++ b/examples/node/src/lib/prompts.ts
@@ -1,0 +1,119 @@
+import { confirm, input, number, search, select } from "@inquirer/prompts"
+import { UsStateCodes, UsStateMap, type UsStateCode } from "@usebridge/sdk-core"
+import { getDefaultServiceTypeIds } from "./env.js"
+
+export async function promptServiceTypeIds(): Promise<string[]> {
+  const defaults = getDefaultServiceTypeIds()
+  const useDefaults = await confirm({
+    message: `Use default service types (${defaults.join(", ")})?`,
+    default: true,
+  })
+
+  if (useDefaults) return defaults
+
+  const raw = await input({
+    message: "Service type IDs (comma-separated)",
+    validate: (value) => (value.trim() ? true : "At least one service type ID is required"),
+  })
+
+  return raw
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean)
+}
+
+export async function promptState(message = "Patient state"): Promise<UsStateCode> {
+  return search({
+    message,
+    source: async (term) => {
+      const query = term?.toLowerCase() ?? ""
+      return UsStateCodes.filter(
+        (code) =>
+          code.toLowerCase().includes(query) || UsStateMap[code].toLowerCase().includes(query),
+      ).map((code) => ({ name: `${code} — ${UsStateMap[code]}`, value: code }))
+    },
+  })
+}
+
+export async function promptMergeStrategy(): Promise<"UNION" | "INTERSECTION" | undefined> {
+  const customize = await confirm({
+    message: "Customize merge strategy?",
+    default: false,
+  })
+
+  if (!customize) return undefined
+
+  return select({
+    message: "Merge strategy",
+    choices: [
+      { name: "UNION — eligible if any service type is eligible", value: "UNION" as const },
+      {
+        name: "INTERSECTION — eligible only if all service types are eligible",
+        value: "INTERSECTION" as const,
+      },
+    ],
+    default: "UNION",
+  })
+}
+
+export async function promptPayerSearchQuery(): Promise<string> {
+  return input({
+    message: "Payer search query",
+    validate: (value) => (value.trim() ? true : "Query is required"),
+  })
+}
+
+export async function promptSearchLimit(): Promise<number> {
+  const limit = await number({
+    message: "Maximum results",
+    default: 10,
+    min: 1,
+    max: 50,
+  })
+
+  return limit ?? 10
+}
+
+export async function promptPayerId(): Promise<string> {
+  return input({
+    message: "Payer ID (pyr_...)",
+    validate: (value) => (value.trim() ? true : "Payer ID is required"),
+  })
+}
+
+export async function promptPatientFields(): Promise<{
+  payerId: string
+  firstName: string
+  lastName: string
+  dateOfBirth: string
+  memberId?: string
+}> {
+  const payerId = await promptPayerId()
+  const firstName = await input({
+    message: "First name",
+    validate: (value) => (value.trim() ? true : "First name is required"),
+  })
+  const lastName = await input({
+    message: "Last name",
+    validate: (value) => (value.trim() ? true : "Last name is required"),
+  })
+  const dateOfBirth = await input({
+    message: "Date of birth (YYYY-MM-DD)",
+    validate: (value) =>
+      /^\d{4}-\d{2}-\d{2}$/.test(value.trim()) ? true : "Use format YYYY-MM-DD",
+  })
+
+  const includeMemberId = await confirm({
+    message: "Include member ID?",
+    default: false,
+  })
+
+  const memberId = includeMemberId
+    ? await input({
+        message: "Member ID",
+        validate: (value) => (value.trim() ? true : "Member ID is required when enabled"),
+      })
+    : undefined
+
+  return { payerId, firstName, lastName, dateOfBirth, memberId }
+}

--- a/examples/node/src/scripts/hard-eligibility.ts
+++ b/examples/node/src/scripts/hard-eligibility.ts
@@ -1,0 +1,74 @@
+import { confirm, input } from "@inquirer/prompts"
+import { getBridgeClient } from "../lib/bridge-client.js"
+import { datestampToDateObject } from "../lib/date-object.js"
+import { printJson, printMessage } from "../lib/output.js"
+import {
+  promptMergeStrategy,
+  promptPatientFields,
+  promptServiceTypeIds,
+  promptState,
+} from "../lib/prompts.js"
+
+async function main() {
+  printMessage("Bridge hard eligibility check\n")
+
+  const serviceTypeIds = await promptServiceTypeIds()
+  const mergeStrategy = await promptMergeStrategy()
+  const useExistingPolicy = await confirm({
+    message: "Use an existing policy ID?",
+    default: false,
+  })
+
+  const bridge = getBridgeClient()
+
+  if (useExistingPolicy) {
+    const policyId = await input({
+      message: "Policy ID (pol_...)",
+      validate: (value) => (value.trim() ? true : "Policy ID is required"),
+    })
+    const state = await promptState()
+
+    printMessage("\nRunning hard eligibility check (existing policy)...\n")
+
+    const result = await bridge.hardEligibility({
+      serviceTypeIds,
+      ...(mergeStrategy ? { mergeStrategy } : {}),
+      policyId: policyId.trim(),
+      state,
+    })
+
+    printJson(result)
+    return
+  }
+
+  const state = await promptState()
+  const patient = await promptPatientFields()
+  const optimisticSoftCheck = await confirm({
+    message: "Enable optimistic soft check?",
+    default: false,
+  })
+
+  printMessage("\nRunning hard eligibility check...\n")
+
+  const result = await bridge.hardEligibility({
+    serviceTypeIds,
+    ...(mergeStrategy ? { mergeStrategy } : {}),
+    ...(optimisticSoftCheck ? { optimisticSoftCheck: true } : {}),
+    state,
+    patient: {
+      payerId: patient.payerId.trim(),
+      firstName: patient.firstName.trim(),
+      lastName: patient.lastName.trim(),
+      dateOfBirth: datestampToDateObject(patient.dateOfBirth),
+      ...(patient.memberId ? { memberId: patient.memberId.trim() } : {}),
+    },
+  })
+
+  printJson(result)
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`Error: ${message}\n`)
+  process.exit(1)
+})

--- a/examples/node/src/scripts/search-payers.ts
+++ b/examples/node/src/scripts/search-payers.ts
@@ -1,0 +1,23 @@
+import { getBridgeClient } from "../lib/bridge-client.js"
+import { printJson, printMessage } from "../lib/output.js"
+import { promptPayerSearchQuery, promptSearchLimit } from "../lib/prompts.js"
+
+async function main() {
+  printMessage("Bridge payer search\n")
+
+  const query = await promptPayerSearchQuery()
+  const limit = await promptSearchLimit()
+
+  printMessage("\nSearching...\n")
+
+  const bridge = getBridgeClient()
+  const result = await bridge.searchPayers({ query: query.trim(), limit })
+
+  printJson(result)
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`Error: ${message}\n`)
+  process.exit(1)
+})

--- a/examples/node/src/scripts/smoke-test.ts
+++ b/examples/node/src/scripts/smoke-test.ts
@@ -1,0 +1,15 @@
+import { getBridgeClient } from "../lib/bridge-client.js"
+import { printJson, printMessage } from "../lib/output.js"
+
+async function main() {
+  const bridge = getBridgeClient()
+
+  printMessage("=== searchPayers (aetna) ===")
+  printJson(await bridge.searchPayers({ query: "aetna", limit: 5 }))
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`Error: ${message}\n`)
+  process.exit(1)
+})

--- a/examples/node/src/scripts/soft-eligibility.ts
+++ b/examples/node/src/scripts/soft-eligibility.ts
@@ -1,0 +1,35 @@
+import { getBridgeClient } from "../lib/bridge-client.js"
+import { printJson, printMessage } from "../lib/output.js"
+import {
+  promptMergeStrategy,
+  promptPayerId,
+  promptServiceTypeIds,
+  promptState,
+} from "../lib/prompts.js"
+
+async function main() {
+  printMessage("Bridge soft eligibility check\n")
+
+  const serviceTypeIds = await promptServiceTypeIds()
+  const mergeStrategy = await promptMergeStrategy()
+  const payerId = await promptPayerId()
+  const state = await promptState()
+
+  printMessage("\nRunning soft eligibility check...\n")
+
+  const bridge = getBridgeClient()
+  const result = await bridge.softEligibility({
+    serviceTypeIds,
+    ...(mergeStrategy ? { mergeStrategy } : {}),
+    payerId: payerId.trim(),
+    state,
+  })
+
+  printJson(result)
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`Error: ${message}\n`)
+  process.exit(1)
+})

--- a/examples/node/tsconfig.json
+++ b/examples/node/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "noEmit": true,
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/examples/node/turbo.json
+++ b/examples/node/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": { "outputs": [] },
+    "dev": { "cache": false, "persistent": true },
+    "test": { "cache": false }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "turbo run clean",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo run build --filter=@usebridge/sdk-core --filter=@usebridge/sdk-react && changeset publish"
+    "release": "turbo run build --filter=@usebridge/sdk-core --filter=@usebridge/sdk --filter=@usebridge/sdk-react && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.8",

--- a/packages/sdk/jest.config.cjs
+++ b/packages/sdk/jest.config.cjs
@@ -1,0 +1,18 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        useESM: true,
+        tsconfig: "tsconfig.test.json",
+      },
+    ],
+  },
+  moduleFileExtensions: ["ts", "js", "json"],
+  extensionsToTreatAsEsm: [".ts"],
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@usebridge/sdk",
+  "version": "0.1.0",
+  "description": "Bridge SDK for non-React clients — server, scripts, and vanilla JS",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --sourcemap --clean",
+    "dev": "tsup src/index.ts --format esm,cjs --dts --sourcemap --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
+    "test": "jest",
+    "clean": "rimraf dist",
+    "version": "yarn version",
+    "publish": "yarn npm publish --access public"
+  },
+  "dependencies": {
+    "@usebridge/sdk-core": "workspace:^"
+  },
+  "peerDependencies": {
+    "@usebridge/api": ">=1.1.0-0"
+  },
+  "devDependencies": {
+    "@jest/globals": "^30.2.0",
+    "@types/jest": "^30.0.0",
+    "@usebridge/api": "1.1.0",
+    "jest": "^30.2.0",
+    "ts-jest": "^29.4.5",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/sdk/src/client/create-bridge-client.ts
+++ b/packages/sdk/src/client/create-bridge-client.ts
@@ -1,0 +1,18 @@
+import { BridgeSdk, type BridgeSdkConfig } from "@usebridge/sdk-core"
+import { runHardEligibility } from "../hard-eligibility/hard-eligibility.js"
+import { runSoftEligibility } from "../soft-eligibility/soft-eligibility.js"
+import type { BridgeClient } from "./types.js"
+
+/**
+ * Creates a BridgeClient for non-React environments.
+ * Pass complete eligibility inputs and receive the final session state.
+ */
+export function createBridgeClient(config: BridgeSdkConfig): BridgeClient {
+  const sdk = new BridgeSdk(config)
+
+  return {
+    searchPayers: (args) => sdk.payerSearch(args),
+    softEligibility: (args) => runSoftEligibility(sdk, args),
+    hardEligibility: (args) => runHardEligibility(sdk, args),
+  }
+}

--- a/packages/sdk/src/client/types.ts
+++ b/packages/sdk/src/client/types.ts
@@ -1,0 +1,25 @@
+import type {
+  HardEligibilitySessionConfig,
+  HardEligibilitySessionState,
+  HardEligibilitySubmissionArgs,
+  PayerSearchResults,
+  SoftEligibilitySessionConfig,
+  SoftEligibilitySessionState,
+  SoftEligibilitySubmissionArgs,
+} from "@usebridge/sdk-core"
+
+export type SoftEligibilityArgs = SoftEligibilitySessionConfig & SoftEligibilitySubmissionArgs
+
+export type HardEligibilityArgs =
+  | (HardEligibilitySessionConfig & HardEligibilitySubmissionArgs)
+  | (HardEligibilitySessionConfig & {
+      policyId: string
+    } & Pick<HardEligibilitySubmissionArgs, "state" | "clinicalInfo">)
+
+export interface BridgeClient {
+  searchPayers(args: { query: string; limit?: number }): Promise<PayerSearchResults>
+
+  softEligibility(args: SoftEligibilityArgs): Promise<SoftEligibilitySessionState>
+
+  hardEligibility(args: HardEligibilityArgs): Promise<HardEligibilitySessionState>
+}

--- a/packages/sdk/src/hard-eligibility/hard-eligibility.test.ts
+++ b/packages/sdk/src/hard-eligibility/hard-eligibility.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, jest } from "@jest/globals"
-import type { HardEligibilitySession, HardEligibilitySessionState } from "@usebridge/sdk-core"
+import type {
+  HardEligibilitySession,
+  HardEligibilitySessionState,
+  HardEligibilitySubmissionArgs,
+} from "@usebridge/sdk-core"
+import type { HardEligibilityArgs } from "../client/types"
 import { runHardEligibility } from "./hard-eligibility"
 
 describe("runHardEligibility", () => {
@@ -37,6 +42,38 @@ describe("runHardEligibility", () => {
       serviceTypeIds: ["svt_abc"],
       mergeStrategy: "INTERSECTION",
       optimisticSoftCheck: true,
+    })
+    expect(submit).toHaveBeenCalledWith({
+      state: "NY",
+      patient,
+      clinicalInfo: { diagnoses: ["F41.1"] },
+    })
+    expect(result).toBe(submitResult)
+  })
+
+  it("omits a falsy policyId from session config for a new policy", async () => {
+    const submitResult: HardEligibilitySessionState = {
+      status: "ELIGIBLE",
+      submitCount: 1,
+    }
+
+    const submit = jest.fn<HardEligibilitySession["submit"]>().mockResolvedValue(submitResult)
+    const createHardEligibilitySession = jest
+      .fn<(...args: unknown[]) => HardEligibilitySession>()
+      .mockReturnValue({ submit } as unknown as HardEligibilitySession)
+
+    const sdk = { createHardEligibilitySession }
+
+    const result = await runHardEligibility(sdk, {
+      serviceTypeIds: ["svt_abc"],
+      policyId: undefined,
+      state: "NY",
+      patient,
+      clinicalInfo: { diagnoses: ["F41.1"] },
+    } as HardEligibilityArgs & { policyId?: undefined } & HardEligibilitySubmissionArgs)
+
+    expect(createHardEligibilitySession).toHaveBeenCalledWith({
+      serviceTypeIds: ["svt_abc"],
     })
     expect(submit).toHaveBeenCalledWith({
       state: "NY",

--- a/packages/sdk/src/hard-eligibility/hard-eligibility.test.ts
+++ b/packages/sdk/src/hard-eligibility/hard-eligibility.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, jest } from "@jest/globals"
+import type { HardEligibilitySession, HardEligibilitySessionState } from "@usebridge/sdk-core"
+import { runHardEligibility } from "./hard-eligibility"
+
+describe("runHardEligibility", () => {
+  const patient = {
+    payerId: "pyr_123",
+    firstName: "Jane",
+    lastName: "Doe",
+    dateOfBirth: { year: "1990", month: "01", day: "15" },
+    memberId: "M123",
+  }
+
+  it("splits session config from submit args for a new policy", async () => {
+    const submitResult: HardEligibilitySessionState = {
+      status: "ELIGIBLE",
+      submitCount: 1,
+    }
+
+    const submit = jest.fn<HardEligibilitySession["submit"]>().mockResolvedValue(submitResult)
+    const createHardEligibilitySession = jest
+      .fn<(...args: unknown[]) => HardEligibilitySession>()
+      .mockReturnValue({ submit } as unknown as HardEligibilitySession)
+
+    const sdk = { createHardEligibilitySession }
+
+    const result = await runHardEligibility(sdk, {
+      serviceTypeIds: ["svt_abc"],
+      mergeStrategy: "INTERSECTION",
+      optimisticSoftCheck: true,
+      state: "NY",
+      patient,
+      clinicalInfo: { diagnoses: ["F41.1"] },
+    })
+
+    expect(createHardEligibilitySession).toHaveBeenCalledWith({
+      serviceTypeIds: ["svt_abc"],
+      mergeStrategy: "INTERSECTION",
+      optimisticSoftCheck: true,
+    })
+    expect(submit).toHaveBeenCalledWith({
+      state: "NY",
+      patient,
+      clinicalInfo: { diagnoses: ["F41.1"] },
+    })
+    expect(result).toBe(submitResult)
+  })
+
+  it("uses policyId in session config and omits patient from submit", async () => {
+    const submitResult: HardEligibilitySessionState = {
+      status: "ELIGIBLE",
+      submitCount: 1,
+    }
+
+    const submit = jest.fn<HardEligibilitySession["submit"]>().mockResolvedValue(submitResult)
+    const createHardEligibilitySession = jest
+      .fn<(...args: unknown[]) => HardEligibilitySession>()
+      .mockReturnValue({ submit } as unknown as HardEligibilitySession)
+
+    const sdk = { createHardEligibilitySession }
+
+    const result = await runHardEligibility(sdk, {
+      serviceTypeIds: ["svt_abc"],
+      policyId: "pol_existing",
+      state: "CA",
+      clinicalInfo: { diagnoses: ["F41.1"] },
+    })
+
+    expect(createHardEligibilitySession).toHaveBeenCalledWith({
+      serviceTypeIds: ["svt_abc"],
+      policyId: "pol_existing",
+    })
+    expect(submit).toHaveBeenCalledWith({
+      state: "CA",
+      clinicalInfo: { diagnoses: ["F41.1"] },
+    })
+    expect(result).toBe(submitResult)
+  })
+})

--- a/packages/sdk/src/hard-eligibility/hard-eligibility.test.ts
+++ b/packages/sdk/src/hard-eligibility/hard-eligibility.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, jest } from "@jest/globals"
-import type {
-  HardEligibilitySession,
-  HardEligibilitySessionState,
-  HardEligibilitySubmissionArgs,
-} from "@usebridge/sdk-core"
+import type { HardEligibilitySession, HardEligibilitySessionState } from "@usebridge/sdk-core"
 import type { HardEligibilityArgs } from "../client/types"
 import { runHardEligibility } from "./hard-eligibility"
 
@@ -70,7 +66,7 @@ describe("runHardEligibility", () => {
       state: "NY",
       patient,
       clinicalInfo: { diagnoses: ["F41.1"] },
-    } as HardEligibilityArgs & { policyId?: undefined } & HardEligibilitySubmissionArgs)
+    } as unknown as HardEligibilityArgs)
 
     expect(createHardEligibilitySession).toHaveBeenCalledWith({
       serviceTypeIds: ["svt_abc"],

--- a/packages/sdk/src/hard-eligibility/hard-eligibility.ts
+++ b/packages/sdk/src/hard-eligibility/hard-eligibility.ts
@@ -1,0 +1,28 @@
+import type {
+  BridgeSdk,
+  HardEligibilitySessionConfig,
+  HardEligibilitySessionState,
+  HardEligibilitySubmissionArgs,
+} from "@usebridge/sdk-core"
+import type { HardEligibilityArgs } from "../client/types.js"
+
+function isExistingPolicyArgs(args: HardEligibilityArgs): args is HardEligibilitySessionConfig & {
+  policyId: string
+} & Pick<HardEligibilitySubmissionArgs, "state" | "clinicalInfo"> {
+  return "policyId" in args && Boolean(args.policyId)
+}
+
+export async function runHardEligibility(
+  sdk: Pick<BridgeSdk, "createHardEligibilitySession">,
+  args: HardEligibilityArgs,
+): Promise<HardEligibilitySessionState> {
+  if (isExistingPolicyArgs(args)) {
+    const { state, clinicalInfo, policyId, ...sessionConfig } = args
+    const session = sdk.createHardEligibilitySession({ ...sessionConfig, policyId })
+    return session.submit({ state, clinicalInfo })
+  }
+
+  const { state, patient, clinicalInfo, ...sessionConfig } = args
+  const session = sdk.createHardEligibilitySession(sessionConfig)
+  return session.submit({ state, patient, clinicalInfo })
+}

--- a/packages/sdk/src/hard-eligibility/hard-eligibility.ts
+++ b/packages/sdk/src/hard-eligibility/hard-eligibility.ts
@@ -22,7 +22,8 @@ export async function runHardEligibility(
     return session.submit({ state, clinicalInfo })
   }
 
-  const { state, patient, clinicalInfo, policyId, ...sessionConfig } = args
+  const { state, patient, clinicalInfo, ...sessionConfig } = args
+  delete (sessionConfig as Partial<Record<"policyId", unknown>>).policyId
   const session = sdk.createHardEligibilitySession(sessionConfig)
   return session.submit({ state, patient, clinicalInfo })
 }

--- a/packages/sdk/src/hard-eligibility/hard-eligibility.ts
+++ b/packages/sdk/src/hard-eligibility/hard-eligibility.ts
@@ -22,7 +22,7 @@ export async function runHardEligibility(
     return session.submit({ state, clinicalInfo })
   }
 
-  const { state, patient, clinicalInfo, ...sessionConfig } = args
+  const { state, patient, clinicalInfo, policyId, ...sessionConfig } = args
   const session = sdk.createHardEligibilitySession(sessionConfig)
   return session.submit({ state, patient, clinicalInfo })
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,2 @@
+export { createBridgeClient } from "./client/create-bridge-client.js"
+export type { BridgeClient, HardEligibilityArgs, SoftEligibilityArgs } from "./client/types.js"

--- a/packages/sdk/src/soft-eligibility/soft-eligibility.test.ts
+++ b/packages/sdk/src/soft-eligibility/soft-eligibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, jest } from "@jest/globals"
+import type {
+  HardEligibilitySession,
+  SoftEligibilitySession,
+  SoftEligibilitySessionState,
+  HardEligibilitySessionState,
+} from "@usebridge/sdk-core"
+import { runSoftEligibility } from "./soft-eligibility"
+
+describe("runSoftEligibility", () => {
+  it("splits session config from submit args", async () => {
+    const submitResult: SoftEligibilitySessionState = {
+      status: "ELIGIBLE",
+      providers: [],
+    }
+
+    const submit = jest.fn<SoftEligibilitySession["submit"]>().mockResolvedValue(submitResult)
+    const createSoftEligibilitySession = jest
+      .fn<(...args: unknown[]) => SoftEligibilitySession>()
+      .mockReturnValue({ submit } as unknown as SoftEligibilitySession)
+
+    const sdk = { createSoftEligibilitySession }
+
+    const result = await runSoftEligibility(sdk, {
+      serviceTypeIds: ["svt_abc"],
+      mergeStrategy: "UNION",
+      payerId: "pyr_123",
+      state: "CA",
+    })
+
+    expect(createSoftEligibilitySession).toHaveBeenCalledWith({
+      serviceTypeIds: ["svt_abc"],
+      mergeStrategy: "UNION",
+    })
+    expect(submit).toHaveBeenCalledWith({
+      payerId: "pyr_123",
+      state: "CA",
+    })
+    expect(result).toBe(submitResult)
+  })
+})

--- a/packages/sdk/src/soft-eligibility/soft-eligibility.ts
+++ b/packages/sdk/src/soft-eligibility/soft-eligibility.ts
@@ -1,0 +1,11 @@
+import type { BridgeSdk, SoftEligibilitySessionState } from "@usebridge/sdk-core"
+import type { SoftEligibilityArgs } from "../client/types.js"
+
+export async function runSoftEligibility(
+  sdk: Pick<BridgeSdk, "createSoftEligibilitySession">,
+  args: SoftEligibilityArgs,
+): Promise<SoftEligibilitySessionState> {
+  const { payerId, state, ...sessionConfig } = args
+  const session = sdk.createSoftEligibilitySession(sessionConfig)
+  return session.submit({ payerId, state })
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/sdk/tsconfig.test.json
+++ b/packages/sdk/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,9 +839,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/aix-ppc64@npm:0.28.1"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/android-arm64@npm:0.25.9"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm64@npm:0.28.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -853,9 +867,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm@npm:0.28.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/android-x64@npm:0.25.9"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-x64@npm:0.28.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -867,9 +895,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-arm64@npm:0.28.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/darwin-x64@npm:0.25.9"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-x64@npm:0.28.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -881,9 +923,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.28.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/freebsd-x64@npm:0.25.9"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-x64@npm:0.28.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -895,9 +951,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm64@npm:0.28.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/linux-arm@npm:0.25.9"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm@npm:0.28.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -909,9 +979,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ia32@npm:0.28.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/linux-loong64@npm:0.25.9"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-loong64@npm:0.28.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -923,9 +1007,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-mips64el@npm:0.28.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/linux-ppc64@npm:0.25.9"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ppc64@npm:0.28.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -937,9 +1035,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-riscv64@npm:0.28.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/linux-s390x@npm:0.25.9"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-s390x@npm:0.28.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -951,9 +1063,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-x64@npm:0.28.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-arm64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/netbsd-arm64@npm:0.25.9"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-arm64@npm:0.28.1"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -965,9 +1091,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-x64@npm:0.28.1"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-arm64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/openbsd-arm64@npm:0.25.9"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.28.1"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -979,9 +1119,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-x64@npm:0.28.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openharmony-arm64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/openharmony-arm64@npm:0.25.9"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openharmony-arm64@npm:0.28.1"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -993,9 +1147,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/sunos-x64@npm:0.28.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/win32-arm64@npm:0.25.9"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-arm64@npm:0.28.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -1007,9 +1175,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-ia32@npm:0.28.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.25.9":
   version: 0.25.9
   resolution: "@esbuild/win32-x64@npm:0.25.9"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-x64@npm:0.28.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1096,6 +1278,253 @@ __metadata:
   version: 2.0.3
   resolution: "@humanwhocodes/object-schema@npm:2.0.3"
   checksum: 10c0/80520eabbfc2d32fe195a93557cef50dfe8c8905de447f022675aaf66abc33ae54098f5ea78548d925aa671cd4ab7c7daa5ad704fe42358c9b5e7db60f80696c
+  languageName: node
+  linkType: hard
+
+"@inquirer/ansi@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@inquirer/ansi@npm:1.0.2"
+  checksum: 10c0/8e408cc628923aa93402e66657482ccaa2ad5174f9db526d9a8b443f9011e9cd8f70f0f534f5fe3857b8a9df3bce1e25f66c96f666d6750490bd46e2b4f3b829
+  languageName: node
+  linkType: hard
+
+"@inquirer/checkbox@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@inquirer/checkbox@npm:4.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/771d23bc6b16cd5c21a4f1073e98e306147f90c0e2487fe887ee054b8bf86449f1f9e6e6f9c218c1aa45ae3be2533197d53654abe9c0545981aebb0920d5f471
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.21":
+  version: 5.1.21
+  resolution: "@inquirer/confirm@npm:5.1.21"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/a95bbdbb17626c484735a4193ed6b6a6fbb078cf62116ec8e1667f647e534dd6618e688ecc7962585efcc56881b544b8c53db3914599bbf2ab842e7f224b0fca
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^10.3.2":
+  version: 10.3.2
+  resolution: "@inquirer/core@npm:10.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    cli-width: "npm:^4.1.0"
+    mute-stream: "npm:^2.0.0"
+    signal-exit: "npm:^4.1.0"
+    wrap-ansi: "npm:^6.2.0"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/f0f27e07fe288e01e3949b4ad216c19751f025ce77c610366e08d8b0f7a135d064dc074732031d251584b454c576f1e5c849e4abe259186dd5d4974c8f85c13e
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^4.2.23":
+  version: 4.2.23
+  resolution: "@inquirer/editor@npm:4.2.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/external-editor": "npm:^1.0.3"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/aa02028ee35ae039a4857b6a9490d295a1b3558f042e7454dee0aa36fbc83ac25586a2dfe0b46a5ea7ea151e3f5cb97a8ee6229131b4619f3b3466ad74b9519f
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/expand@npm:4.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/294c92652760c3d1a46c4b900a99fd553ea9e5734ba261d4e71d7b8499d86a8b15e38a2467ddb7c95c197daf7e472bdab209fc3f7c38cbc70842cd291f4ce39d
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@inquirer/external-editor@npm:1.0.3"
+  dependencies:
+    chardet: "npm:^2.1.1"
+    iconv-lite: "npm:^0.7.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/82951cb7f3762dd78cca2ea291396841e3f4adfe26004b5badfed1cec4b6a04bb567dff94d0e41b35c61bdd7957317c64c22f58074d14b238d44e44d9e420019
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^1.0.15":
+  version: 1.0.15
+  resolution: "@inquirer/figures@npm:1.0.15"
+  checksum: 10c0/6e39a040d260ae234ae220180b7994ff852673e20be925f8aa95e78c7934d732b018cbb4d0ec39e600a410461bcb93dca771e7de23caa10630d255692e440f69
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "@inquirer/input@npm:4.3.1"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/9e81d6ae56e5b59f96475ae1327e7e7beeef0d917b83762e0c2ed5a75239ad6b1a39fc05553ce45fe6f6de49681dade8704b5f1c11c2f555663a74d0ac998af3
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.23":
+  version: 3.0.23
+  resolution: "@inquirer/number@npm:3.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/3944a524be2a2e0834822a0e483f2e2fd56ad597b5feeca2155b956821f88e22e07ce3816f66113b040601636ed7146865aee7d7afb2a06939acc77491330ccc
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/password@npm:4.0.23"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/9fd3d0462d02735bb1521c4e221d057a94d9aaac308e9a192e59d6c1e8efc707c2376ab627151d589bc3633f6b14b74b60b91c3d473a32adfd100ef1f6cfdef7
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^7.5.1":
+  version: 7.10.1
+  resolution: "@inquirer/prompts@npm:7.10.1"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.3.2"
+    "@inquirer/confirm": "npm:^5.1.21"
+    "@inquirer/editor": "npm:^4.2.23"
+    "@inquirer/expand": "npm:^4.0.23"
+    "@inquirer/input": "npm:^4.3.1"
+    "@inquirer/number": "npm:^3.0.23"
+    "@inquirer/password": "npm:^4.0.23"
+    "@inquirer/rawlist": "npm:^4.1.11"
+    "@inquirer/search": "npm:^3.2.2"
+    "@inquirer/select": "npm:^4.4.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/eac309cc75712bc94fc8b6761d6a736786ca1942cf9c90805b2a6049a05ce6131bcfb3aa703d1dbe66874d1b78c2b446044ad9735a2bb76743b8ddcb3dcb4d2a
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "@inquirer/rawlist@npm:4.1.11"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/33792b40cd0fbf77f547c9c4805087dd1188342c6a5ca512c73b0b6c4d132225fc5ae8bc4fd5035309484da3698a90fcef17aad100b9ae57624fda7b07d92227
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@inquirer/search@npm:3.2.2"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/e7849663a51fe95e3ce99d274c815b8dc8933d6a5ddcaaf6130bf43f5f10316062c9f7a37c2923a14b8dcd09d202b0bb9cc3eaf0adb0336f6a704ea52e03ef8c
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@inquirer/select@npm:4.4.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/6978a5a92928b4d439dd6b688f2db51fd49be209f24be224bb81ed8f75b76e0715e79bdb05dab2a33bbdc7091c779a99f8603fe0ca199f059528ca2b1d0d4944
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^3.0.10":
+  version: 3.0.10
+  resolution: "@inquirer/type@npm:3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/a846c7a570e3bf2657d489bcc5dcdc3179d24c7323719de1951dcdb722400ac76e5b2bfe9765d0a789bc1921fac810983d7999f021f30a78a6a174c23fc78dc9
   languageName: node
   linkType: hard
 
@@ -2605,6 +3034,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@usebridge/sdk@workspace:*, @usebridge/sdk@workspace:packages/sdk":
+  version: 0.0.0-use.local
+  resolution: "@usebridge/sdk@workspace:packages/sdk"
+  dependencies:
+    "@jest/globals": "npm:^30.2.0"
+    "@types/jest": "npm:^30.0.0"
+    "@usebridge/api": "npm:1.1.0"
+    "@usebridge/sdk-core": "workspace:^"
+    jest: "npm:^30.2.0"
+    ts-jest: "npm:^29.4.5"
+    tsup: "npm:^8.5.0"
+    typescript: "npm:^5.9.3"
+  peerDependencies:
+    "@usebridge/api": ">=1.1.0-0"
+  languageName: unknown
+  linkType: soft
+
 "abbrev@npm:^3.0.0":
   version: 3.0.1
   resolution: "abbrev@npm:3.0.1"
@@ -3028,6 +3474,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chardet@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "chardet@npm:2.1.1"
+  checksum: 10c0/d8391dd412338442b3de0d3a488aa9327f8bcf74b62b8723d6bd0b85c4084d50b731320e0a7c710edb1d44de75969995d2784b80e4c13b004a6c7a0db4c6e793
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:^4.0.3":
   version: 4.0.3
   resolution: "chokidar@npm:4.0.3"
@@ -3062,6 +3515,13 @@ __metadata:
   version: 2.1.0
   resolution: "cjs-module-lexer@npm:2.1.0"
   checksum: 10c0/91cf28686dc3948e4a06dfa03a2fccb14b7a97471ffe7ae0124f62060ddf2de28e8e997f60007babe6e122b1b06a47c01a1b72cc015f185824d9cac3ccfa5533
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
   languageName: node
   linkType: hard
 
@@ -3306,6 +3766,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.6.1":
+  version: 16.6.1
+  resolution: "dotenv@npm:16.6.1"
+  checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
+  languageName: node
+  linkType: hard
+
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
@@ -3478,6 +3945,95 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/aaa1284c75fcf45c82f9a1a117fe8dc5c45628e3386bda7d64916ae27730910b51c5aec7dd45a6ba19256be30ba2935e64a8f011a3f0539833071e06bf76d5b3
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:~0.28.0":
+  version: 0.28.1
+  resolution: "esbuild@npm:0.28.1"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.28.1"
+    "@esbuild/android-arm": "npm:0.28.1"
+    "@esbuild/android-arm64": "npm:0.28.1"
+    "@esbuild/android-x64": "npm:0.28.1"
+    "@esbuild/darwin-arm64": "npm:0.28.1"
+    "@esbuild/darwin-x64": "npm:0.28.1"
+    "@esbuild/freebsd-arm64": "npm:0.28.1"
+    "@esbuild/freebsd-x64": "npm:0.28.1"
+    "@esbuild/linux-arm": "npm:0.28.1"
+    "@esbuild/linux-arm64": "npm:0.28.1"
+    "@esbuild/linux-ia32": "npm:0.28.1"
+    "@esbuild/linux-loong64": "npm:0.28.1"
+    "@esbuild/linux-mips64el": "npm:0.28.1"
+    "@esbuild/linux-ppc64": "npm:0.28.1"
+    "@esbuild/linux-riscv64": "npm:0.28.1"
+    "@esbuild/linux-s390x": "npm:0.28.1"
+    "@esbuild/linux-x64": "npm:0.28.1"
+    "@esbuild/netbsd-arm64": "npm:0.28.1"
+    "@esbuild/netbsd-x64": "npm:0.28.1"
+    "@esbuild/openbsd-arm64": "npm:0.28.1"
+    "@esbuild/openbsd-x64": "npm:0.28.1"
+    "@esbuild/openharmony-arm64": "npm:0.28.1"
+    "@esbuild/sunos-x64": "npm:0.28.1"
+    "@esbuild/win32-arm64": "npm:0.28.1"
+    "@esbuild/win32-ia32": "npm:0.28.1"
+    "@esbuild/win32-x64": "npm:0.28.1"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/29cd456a79ce35ac2c7e05fe871330416b2c395c045d849653f843e51378d6e0d6e774d6dcd01b35f4e83238a29bf8decd04fcd34b3780c589a250b21e5f92bb
   languageName: node
   linkType: hard
 
@@ -3896,7 +4452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.3, fsevents@npm:~2.3.2":
+"fsevents@npm:^2.3.3, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -3906,7 +4462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -4159,6 +4715,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.7.0":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
   languageName: node
   linkType: hard
 
@@ -5303,6 +5868,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mute-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mute-stream@npm:2.0.0"
+  checksum: 10c0/2cf48a2087175c60c8dcdbc619908b49c07f7adcfc37d29236b0c5c612d6204f789104c98cc44d38acab7b3c96f4a3ec2cfdc4934d0738d876dbefa2a12c69f4
+  languageName: node
+  linkType: hard
+
 "mz@npm:^2.7.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
@@ -5410,6 +5982,21 @@ __metadata:
   checksum: 10c0/5b1eadd554cd2cb1f030335d71a9363d16d86453f60a2331333887804c8b4b04a16fcb1ddb58229b792b6c365dbd0fafd9ccacd727c85134101a124bd6b4c06a
   languageName: node
   linkType: hard
+
+"node-demo@workspace:examples/node":
+  version: 0.0.0-use.local
+  resolution: "node-demo@workspace:examples/node"
+  dependencies:
+    "@inquirer/prompts": "npm:^7.5.1"
+    "@usebridge/api": "npm:>=1.1.0-0"
+    "@usebridge/sdk": "workspace:*"
+    "@usebridge/sdk-core": "workspace:*"
+    dotenv: "npm:^16.6.1"
+    envalid: "npm:^8.1.0"
+    tsx: "npm:^4.20.3"
+    typescript: "npm:^5.9.3"
+  languageName: unknown
+  linkType: soft
 
 "node-gyp@npm:latest":
   version: 11.3.0
@@ -6237,7 +6824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
@@ -6747,6 +7334,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsx@npm:^4.20.3":
+  version: 4.22.4
+  resolution: "tsx@npm:4.22.4"
+  dependencies:
+    esbuild: "npm:~0.28.0"
+    fsevents: "npm:~2.3.3"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/3df31eb4929ff501b40b122163705b201ea57a492581e14312ae95d21eb015b33ded46a3fd564f9c89a0e8083186987fc4f10dd38182c4ad6241605974f6c927
+  languageName: node
+  linkType: hard
+
 "turbo-darwin-64@npm:2.6.1":
   version: 2.6.1
   resolution: "turbo-darwin-64@npm:2.6.1"
@@ -7163,6 +7765,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^8.1.0":
   version: 8.1.0
   resolution: "wrap-ansi@npm:8.1.0"
@@ -7252,6 +7865,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
+  languageName: node
+  linkType: hard
+
+"yoctocolors-cjs@npm:^2.1.3":
+  version: 2.1.3
+  resolution: "yoctocolors-cjs@npm:2.1.3"
+  checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New public eligibility API surface and hard-check arg routing (including optimistic soft check) could affect integrators, though behavior delegates to existing sdk-core sessions with unit test coverage.
> 
> **Overview**
> Introduces **`@usebridge/sdk`**, a publishable package for servers, scripts, and other non-React clients. **`createBridgeClient`** wraps `@usebridge/sdk-core` and exposes **`searchPayers`**, **`softEligibility`**, and **`hardEligibility`** as single-call APIs that create a session, submit full inputs, and return the final session state.
> 
> **`runSoftEligibility`** and **`runHardEligibility`** split combined args into session config vs submit payload, including **existing-policy** hard checks (`policyId` + `state`) vs new-policy flows (patient + optional **`optimisticSoftCheck`**). Unit tests cover that wiring.
> 
> Adds **`examples/node`** (`node-demo`) with interactive CLI scripts for payer search, soft/hard eligibility, env loading, and a hard-check prompt for optimistic soft check. Root **`release`** now builds `@usebridge/sdk` alongside core and react; **README** documents the three-package split and a `@usebridge/sdk` usage sample.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48889433564b517c74cd81ec74bccd49a66e19ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->