### PR TITLE
(dev) Release the `sdk` package, too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,6 @@ jobs:
           yarn workspace @usebridge/sdk-react version $VERSION -i
 
       - name: Build and Publish packages
-        run: yarn turbo run publish --filter=@usebridge/sdk-core --filter=@usebridge/sdk-react
+        run: yarn turbo run publish --filter=@usebridge/sdk-core --filter=@usebridge/sdk-react --filter=@usebridge/sdk
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that widens which workspace gets published; no application runtime logic is modified.
> 
> **Overview**
> **GitHub release workflow** now includes `@usebridge/sdk` in the Turbo `publish` step alongside `@usebridge/sdk-core` and `@usebridge/sdk-react`, so that package is built and published to npm when a release is published.
> 
> The version-bump step is unchanged and still only runs `yarn workspace` version on `sdk-core` and `sdk-react`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65c980a9d1aa31965f7a9e5920a4d442c6b7dddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->