### PR TITLE
(dev) Tick up sdk version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           VERSION=${VERSION#v}
           yarn workspace @usebridge/sdk-core version $VERSION -i
           yarn workspace @usebridge/sdk-react version $VERSION -i
+          yarn workspace @usebridge/sdk version $VERSION -i
 
       - name: Build and Publish packages
         run: yarn turbo run publish --filter=@usebridge/sdk-core --filter=@usebridge/sdk-react --filter=@usebridge/sdk


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line CI change with no runtime or security impact.
> 
> **Overview**
> The GitHub **Release** workflow now runs `yarn workspace @usebridge/sdk version` with the release tag (same as `@usebridge/sdk-core` and `@usebridge/sdk-react`).
> 
> **Build and Publish** already included `@usebridge/sdk`; this change ensures that package’s `package.json` version is updated before publish so it stays in sync with the other SDK workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5166e94760b6db0848a9954618f9738df2de75e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->