### PR TITLE
Bump picomatch to 2.3.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6285,9 +6285,9 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^2.0.4, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency update with no direct code changes; typical low-impact maintenance.
> 
> **Overview**
> Updates the resolved **picomatch** version from **2.3.1** to **2.3.2** in `yarn.lock` for the shared `^2.0.4` / `^2.3.1` range entry (checksum updated accordingly). No application source changes; consumers such as **anymatch** and **micromatch** pick up the newer patch via the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc4a0392132c27c5840affff7e87241c4f3f3dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->