### PR TITLE
Specify publish registry explicitly

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,5 +3,6 @@ npmPublishAccess: public
 npmScopes:
   usebridge:
     npmRegistryServer: "https://registry.npmjs.org"
+    npmPublishRegistry: "https://registry.npmjs.org"
     npmAlwaysAuth: true
     npmAuthToken: "${NODE_AUTH_TOKEN:-}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only change to Yarn/npm publish routing with no runtime or application code impact.
> 
> **Overview**
> Adds **`npmPublishRegistry: "https://registry.npmjs.org"`** to the `@usebridge` scope in `.yarnrc.yml`, so Yarn publishes scoped packages to the public npm registry explicitly instead of relying on install-registry settings alone.
> 
> Also restores a trailing newline at the end of the file (no functional change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7379b5c831cf01f915ab52aa32c749c35ae285a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->