### PR TITLE
Validate token before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
           yarn workspace @usebridge/sdk-react version $VERSION -i
           yarn workspace @usebridge/sdk version $VERSION -i
 
+      - name: Verify npm publish auth
+        run: yarn workspace @usebridge/sdk-core npm whoami --publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Build and Publish packages
         run: yarn turbo run publish --filter=@usebridge/sdk-core --filter=@usebridge/sdk-react --filter=@usebridge/sdk
         env:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that adds a pre-publish auth check; no application or package runtime behavior changes.
> 
> **Overview**
> Adds a **Verify npm publish auth** step to the release workflow, running immediately after package versions are set and **before** the build/publish turbo job.
> 
> The step runs `yarn workspace @usebridge/sdk-core npm whoami --publish` with `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN`, so a missing or invalid token fails the workflow early instead of after a full build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587971a19e32ad587331e16dddf43274112ab27e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->