### PR TITLE
Fix auth check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           yarn workspace @usebridge/sdk version $VERSION -i
 
       - name: Verify npm publish auth
-        run: yarn workspace @usebridge/sdk-core npm whoami --publish
+        run: yarn npm whoami --scope usebridge
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change to a pre-publish auth check; no runtime or application code is affected.
> 
> **Overview**
> The release workflow’s **Verify npm publish auth** step no longer runs `npm whoami` only inside `@usebridge/sdk-core`. It now uses **`yarn npm whoami --scope usebridge`**, matching the `@usebridge` scope configured in `setup-node` and checking registry auth for the whole org scope before Turbo publishes all three packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c69f4516822d57bf0a713945542ed740b6dae7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->