### PR TITLE
DEV-1394 differentiate between retryable and non-retryable API errors

### DIFF
--- a/examples/react-demo/src/app/components/payer-autocomplete-field.tsx
+++ b/examples/react-demo/src/app/components/payer-autocomplete-field.tsx
@@ -7,7 +7,7 @@ import type { Payer } from "@usebridge/sdk-core"
 
 export const PayerAutocompleteField = () => {
   const [inputValue, setInputValue] = useState("")
-  const { results, isLoading } = usePayerAutocomplete(inputValue, { limit: 50 })
+  const { results, isLoading, error } = usePayerAutocomplete(inputValue, { limit: 50 })
   const { value, setValue, isDisabled } = useEligibilityInputField("payer")
 
   return (
@@ -25,6 +25,7 @@ export const PayerAutocompleteField = () => {
         <TextField
           {...params}
           disabled={isDisabled}
+          error={Boolean(error)}
           variant="outlined"
           size="medium"
           label="Payer"

--- a/packages/react/src/lib/retry-loop.ts
+++ b/packages/react/src/lib/retry-loop.ts
@@ -6,32 +6,46 @@ export class RetryLoopCancelledError extends Error {
 }
 
 /**
- * This utility function retries the given function forever
+ * Decision for how the retry loop should handle a failure
+ * - retry: wait and try again
+ * - cancel: stop without surfacing the error (stale / unmounted)
+ * - fail: stop and rethrow the original error (irrecoverable)
+ */
+export type RetryDecision = "retry" | "cancel" | "fail"
+
+/**
+ * This utility function retries the given function until it succeeds,
+ * is cancelled, or hits an irrecoverable error
  * Useful for an API that must resolve (e.g. payer search)
  * @param fn the async function to retry
- * @param shouldRetry a function that returns true if the retry should continue, false to stop
+ * @param getRetryDecision called with the caught error; returns how to proceed
  * @param delayMs the delay between retries, defaults to 500ms
  *
  * @returns the result of the function when it succeeds
  *
- * @throws {RetryLoopCancelledError} if the shouldRetry function returns false
+ * @throws {RetryLoopCancelledError} if getRetryDecision returns "cancel"
+ * @throws the original error if getRetryDecision returns "fail"
  */
 export async function retryLoop<T>(
   fn: () => Promise<T>,
-  shouldRetry: () => boolean,
+  getRetryDecision: (err: unknown) => RetryDecision,
   delayMs = 500,
 ): Promise<T> {
-  let cancelled = false
-  while (!cancelled) {
+  let decision: RetryDecision = "retry"
+  let lastError: unknown
+
+  while (decision === "retry") {
     try {
       return await fn()
-    } catch (_) {
-      if (!shouldRetry()) {
-        cancelled = true
-      } else {
+    } catch (err) {
+      lastError = err
+      decision = getRetryDecision(err)
+      if (decision === "retry") {
         await new Promise((r) => setTimeout(r, delayMs))
       }
     }
   }
-  throw new RetryLoopCancelledError()
+
+  if (decision === "cancel") throw new RetryLoopCancelledError()
+  throw lastError
 }

--- a/packages/react/src/payer-search/use-payer-autocomplete.ts
+++ b/packages/react/src/payer-search/use-payer-autocomplete.ts
@@ -9,6 +9,11 @@ import type { Payer } from "@usebridge/sdk-core"
 // We'll store these locally, they won't change within a user session
 const resultCache = new Map<string, Payer[]>()
 
+// Results are truncated to 'limit', so it forms part of the cache identity
+function toCacheKey(normalizedQuery: string, limit: number): string {
+  return `${limit}:${normalizedQuery}`
+}
+
 function toError(err: unknown): Error {
   if (err instanceof Error) return err
   return new Error(String(err))
@@ -80,8 +85,10 @@ export function usePayerAutocomplete(
     // Tick the request ID up, so we ignore everything before this
     const thisId = ++reqId.current
 
+    const cacheKey = toCacheKey(normalizedQuery, limit)
+
     // If the query is in the cache, use it immediately
-    const cachedResults = resultCache.get(normalizedQuery)
+    const cachedResults = resultCache.get(cacheKey)
     if (cachedResults) {
       setIsLoading(false)
       setResults(cachedResults)
@@ -110,7 +117,7 @@ export function usePayerAutocomplete(
         if (!isMounted()) return
 
         // Write these into the cache
-        resultCache.set(normalizedQuery, response.items)
+        resultCache.set(cacheKey, response.items)
 
         // If this is not the latest request, ignore it
         if (thisId !== reqId.current) return
@@ -124,6 +131,7 @@ export function usePayerAutocomplete(
         if (err instanceof RetryLoopCancelledError) return
         if (!isMounted() || thisId !== reqId.current) return
 
+        setResults([])
         setIsLoading(false)
         setError(toError(err))
       }

--- a/packages/react/src/payer-search/use-payer-autocomplete.ts
+++ b/packages/react/src/payer-search/use-payer-autocomplete.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useIsMounted } from "usehooks-ts"
+import { BridgeApiError } from "@usebridge/api"
 import { retryLoop, RetryLoopCancelledError } from "../lib/retry-loop.js"
 import { usePayerSearch } from "./use-payer-search.js"
 import { omit } from "lodash-es"
@@ -7,6 +8,26 @@ import type { Payer } from "@usebridge/sdk-core"
 
 // We'll store these locally, they won't change within a user session
 const resultCache = new Map<string, Payer[]>()
+
+function toError(err: unknown): Error {
+  if (err instanceof Error) return err
+  return new Error(String(err))
+}
+
+/**
+ * Whether a payer-search failure is worth retrying
+ * Retries transient failures; fails on irrecoverable client errors
+ */
+function isRetryablePayerSearchError(err: unknown): boolean {
+  if (err instanceof BridgeApiError && err.statusCode != null) {
+    // Rate-limited: keep trying
+    if (err.statusCode === 429) return true
+    // Other 4xx (bad request, forbidden, etc.): won't recover by retrying
+    if (err.statusCode >= 400 && err.statusCode < 500) return false
+  }
+  // Network, timeout, 5xx, unknown: keep looping
+  return true
+}
 
 /**
  * Providers autocomplete functionality for the Payer search
@@ -32,6 +53,10 @@ export function usePayerAutocomplete(
    * The results to display currently
    */
   results: Payer[]
+  /**
+   * Irrecoverable error from the latest search, if any
+   */
+  error?: Error
 } {
   // We expect a 'BridgeSdk' to be available in the context
   const payerSearch = usePayerSearch()
@@ -41,6 +66,7 @@ export function usePayerAutocomplete(
   // Track the state
   const [isLoading, setIsLoading] = useState(false)
   const [results, setResults] = useState<Payer[]>([])
+  const [error, setError] = useState<Error | undefined>()
 
   // We don't need to run again if it's just whitespace
   const normalizedQuery = query.trim().toLowerCase()
@@ -59,6 +85,7 @@ export function usePayerAutocomplete(
     if (cachedResults) {
       setIsLoading(false)
       setResults(cachedResults)
+      setError(undefined)
       return
     }
 
@@ -66,12 +93,17 @@ export function usePayerAutocomplete(
     async function run() {
       // Move into the loading state, we're going to be waiting
       setIsLoading(true)
+      setError(undefined)
 
       try {
-        // Run the search on a loop, until it resolves, or we unmount/move on
+        // Run the search on a loop, until it resolves, fails irrecoverably, or we unmount/move on
         const response = await retryLoop(
           () => payerSearch({ query: normalizedQuery, limit }),
-          () => isMounted() && thisId === reqId.current,
+          (err) => {
+            if (!isMounted() || thisId !== reqId.current) return "cancel"
+            if (!isRetryablePayerSearchError(err)) return "fail"
+            return "retry"
+          },
         )
 
         // If we've unmounted, do nothing
@@ -86,10 +118,14 @@ export function usePayerAutocomplete(
         // Use these results
         setIsLoading(false)
         setResults(response.items)
+        setError(undefined)
       } catch (err) {
         // If the retry loop was canceled, we don't need to worry about this
         if (err instanceof RetryLoopCancelledError) return
-        throw err
+        if (!isMounted() || thisId !== reqId.current) return
+
+        setIsLoading(false)
+        setError(toError(err))
       }
     }
 
@@ -98,7 +134,7 @@ export function usePayerAutocomplete(
 
   // Memoize what we return here
   return useMemo(
-    () => ({ isLoading, results: results.map((r) => omit(r, "code")) }),
-    [isLoading, results],
+    () => ({ isLoading, results: results.map((r) => omit(r, "code")), error }),
+    [isLoading, results, error],
   )
 }

--- a/packages/react/src/payer-search/use-payer-autocomplete.ts
+++ b/packages/react/src/payer-search/use-payer-autocomplete.ts
@@ -20,8 +20,8 @@ function toError(err: unknown): Error {
  */
 function isRetryablePayerSearchError(err: unknown): boolean {
   if (err instanceof BridgeApiError && err.statusCode != null) {
-    // Rate-limited: keep trying
-    if (err.statusCode === 429) return true
+    // Rate-limited/time-out: keep trying
+    if (err.statusCode === 429 || err.statusCode === 408) return true
     // Other 4xx (bad request, forbidden, etc.): won't recover by retrying
     if (err.statusCode >= 400 && err.statusCode < 500) return false
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes shared retry behavior and payer-search error handling; misclassified status codes could either spin retries or fail searches early, and the new `error` return is a public hook API change.
> 
> **Overview**
> Payer autocomplete no longer retries forever on **irrecoverable** payer-search failures. **`retryLoop`** now takes a **`getRetryDecision(err)`** callback that returns **`retry`**, **`cancel`**, or **`fail`** instead of a boolean **`shouldRetry`**, and rethrows the original error on **`fail`**.
> 
> **`usePayerAutocomplete`** classifies **`BridgeApiError`** responses: most **4xx** (except **408**/**429**) are non-retryable; transient/network/**5xx** keep retrying. Irrecoverable failures clear results, stop loading, and set an optional **`error`** on the hook return value. Result cache keys now include **`limit`** so different page sizes do not share entries.
> 
> The react demo payer field passes **`error`** into the MUI **`TextField`** **`error`** prop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6b3f77cdd8876b20cfb5bcedda5843f8950f47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->