### PR TITLE
Bump to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22.x"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # setup-node@v5 auto-detects yarn from packageManager and runs it before
+      # Corepack is enabled; disable that and enable Corepack explicitly.
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22.x"
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -20,7 +20,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Enable Corepack
-        run: corepack enable
-
+      # setup-node@v5 auto-detects yarn from packageManager and runs it before
+      # Corepack is enabled; disable that and enable Corepack explicitly.
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@usebridge"
+          package-manager-cache: false
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install deps
         run: yarn install --immutable

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "version-packages": "changeset version",
     "release": "turbo run build --filter=@usebridge/sdk-core --filter=@usebridge/sdk --filter=@usebridge/sdk-react && changeset publish"
   },
+  "resolutions": {
+    "tmp": "^0.2.7"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.27.8",
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7179,7 +7179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
+"tmp@npm:^0.2.7":
   version: 0.2.7
   resolution: "tmp@npm:0.2.7"
   checksum: 10c0/59eb55584f2f07210d3231b6a1f6b5c2b9794d8a7b509c8ee867ed2acad6d2245ee2448b7937b676ffbff3155a70077edde8a69f9d7cf0f90c86a62e8910c357


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and dependency-resolution changes only; no application runtime or security logic is modified.
> 
> **Overview**
> Upgrades **CI** and **release** workflows from `actions/checkout@v4` and `actions/setup-node@v4` to **v5**, and documents that `setup-node@v5` can run Yarn before Corepack is enabled.
> 
> Both workflows set **`package-manager-cache: false`** on setup-node, keep **Corepack** enabled explicitly after setup, and use **`yarn install --immutable`** in CI (replacing `--frozen-lockfile`). The release job reorders steps so Corepack runs after Node setup, matching CI.
> 
> Root **`package.json`** adds a **`resolutions`** entry forcing **`tmp@^0.2.7`**, with the lockfile updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a955d8feb6f58188cb8a1c920e916b6ae76eb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->