### PR TITLE
Use NPM trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v5
@@ -21,7 +20,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          # npm trusted publishing requires npm >=11.5.1; Node 24 includes it.
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@usebridge"
           package-manager-cache: false
@@ -40,12 +40,19 @@ jobs:
           yarn workspace @usebridge/sdk-react version $VERSION -i
           yarn workspace @usebridge/sdk version $VERSION -i
 
-      - name: Verify npm publish auth
-        run: yarn npm whoami --scope usebridge
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build packages
+        run: yarn turbo run build --filter=@usebridge/sdk-core --filter=@usebridge/sdk-react --filter=@usebridge/sdk
 
-      - name: Build and Publish packages
-        run: yarn turbo run publish --filter=@usebridge/sdk-core --filter=@usebridge/sdk-react --filter=@usebridge/sdk
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Pack with Yarn so workspace dependency ranges are converted to the
+      # release version, then publish with npm so it can use GitHub OIDC.
+      - name: Pack packages
+        run: |
+          yarn workspace @usebridge/sdk-core pack --out "$RUNNER_TEMP/usebridge-sdk-core.tgz"
+          yarn workspace @usebridge/sdk-react pack --out "$RUNNER_TEMP/usebridge-sdk-react.tgz"
+          yarn workspace @usebridge/sdk pack --out "$RUNNER_TEMP/usebridge-sdk.tgz"
+
+      - name: Publish packages
+        run: |
+          npm publish "$RUNNER_TEMP/usebridge-sdk-core.tgz" --access public
+          npm publish "$RUNNER_TEMP/usebridge-sdk-react.tgz" --access public
+          npm publish "$RUNNER_TEMP/usebridge-sdk.tgz" --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           # npm trusted publishing requires npm >=11.5.1; Node 24 includes it.
           node-version: "24.x"
-          registry-url: "https://registry.npmjs.org"
-          scope: "@usebridge"
           package-manager-cache: false
 
       - name: Enable Corepack

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "Headless core SDK for Bridge - framework-agnostic",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/use-bridge/sdk-typescript.git",
+    "directory": "packages/core"
+  },
   "sideEffects": false,
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "React hooks for Bridge headless SDK",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/use-bridge/sdk-typescript.git",
+    "directory": "packages/react"
+  },
   "sideEffects": false,
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "Bridge SDK for non-React clients — server, scripts, and vanilla JS",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/use-bridge/sdk-typescript.git",
+    "directory": "packages/sdk"
+  },
   "sideEffects": false,
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the production npm publish path (auth, Node version, pack vs turbo publish). A misconfigured OIDC/trusted-publisher setup could fail or skip releases; no app runtime or auth logic is touched.
> 
> **Overview**
> Switches the GitHub Release workflow from `NPM_TOKEN` auth to **npm trusted publishing** via OIDC.
> 
> The job now uses Node 24 (npm ≥11.5.1), drops `contents: write` / `pull-requests: write` and the npm registry token setup, then **packs with Yarn** (so workspace ranges become real versions) and **publishes the tarballs with `npm publish`**. `repository` metadata is added on the three SDK packages so npm can associate them with the GitHub repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bffd66738733dbdfe03bede449319a82462096b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->